### PR TITLE
EZP-27292: Add missing documentation

### DIFF
--- a/docs/tutorial/build_the_bundle.md
+++ b/docs/tutorial/build_the_bundle.md
@@ -1,0 +1,11 @@
+# Build the bundle
+
+FieldTypes, like any other eZ Platform extensions, must be provided as Symfony 2 bundles. This chapter covers the creation and organization of this bundle.
+
+First, you will see how to generate the skeleton for a standard Symfony 2 bundle using the console: [Create the bundle](create_the_bundle.md). Then, you can learn about the suggested structure for storing a Field Type inside a bundle: [Structure the bundle](structure_the_bundle.md).
+
+------------------------------------------------------------------------
+
+⬅ Previous: [Introduction to "Creating a Tweet Field Type" tutorial](creating_a_tweet_fieldtype.md)
+
+Next: [Create the bundle](create_the_bundle.md) ➡

--- a/docs/tutorial/create_the_bundle.md
+++ b/docs/tutorial/create_the_bundle.md
@@ -1,0 +1,73 @@
+# Create the bundle
+
+Once you have [installed eZ Platform](https://doc.ez.no/x/opPfAQ), including the creation of a database for the tutorial, [configured your server](https://doc.ez.no/pages/viewpage.action?pageId=31429536), and [started your web server](https://doc.ez.no/display/DEVELOPER/Web+Server), you need to create a code base for the tutorial.
+
+We will use [the Symfony 2 extension mechanism, bundles,](http://symfony.com/doc/current/cookbook/bundles/index.html) to wrap the Fieldtype. You can get started with a bundle using the built-in Symfony 2 bundle generator, following the instructions on this page.
+Then you will configure your Bundle to be able to write the code you need to create a Field Type.
+
+The [tutorial's Github repository](https://github.com/ezsystems/TweetFieldTypeBundle) shows you the Bundle in a finished state.
+
+## Generating the bundle
+
+From the eZ Platform root, run the following:
+
+``` bash
+php app/console generate:bundle
+```
+
+First, you are asked:
+
+``` bash
+Are you planning on sharing this bundle across multiple applications? [no]: yes <enter>
+```
+
+Type the answer `yes` and submit it with an Enter.
+
+Next you will be asked about the namespace of your bundle.
+
+#### More about naming bundles
+
+See (http://symfony.com/doc/current/cookbook/bundles/best_practices.html#bundle-name) for more details on bundle naming conventions.
+
+Put **EzSystems\\TweetFieldTypeBundle** as Bundle namespace, then the name of the bundle will be hinted from this entry.
+
+``` bash
+Bundle namespace: EzSystems\TweetFieldTypeBundle<enter>
+```
+
+Next, you must select the bundle name. Choose a preferably unique name for the Field Type: `TweetFieldTypeBundle`. Add the vendor name (in this case, `EzSystems`, but you can of course substitute it with your own) and end the name with `Bundle`:
+
+``` bash
+Based on the namespace, we suggest EzSystemsTweetFieldTypeBundle.
+
+Bundle name [EzSystemsTweetFieldTypeBundle]:<enter>
+```
+
+You are then asked for the target directory. Begin within the `src` folder, but you could (and should!) version it and have it moved to `vendor` at some point. Again, this is the default, so just hit Enter.
+
+``` bash
+Target Directory [src/]:<enter>
+```
+
+You must then specify which format the configuration will be generated as. Use yml, since it is what is used in eZ Platform itself. Of course, any other format could be used.
+
+``` bash
+Configuration format (annotation, yml, xml, php, annotation): yml<enter>
+```
+
+Our bundle should now be generated. Navigate to `src/EzSystemsTweetFieldTypeBundle` and you should see the following structure:
+
+``` bash
+$ ls -l src/EzSystemsTweetFieldTypeBundle
+Controller
+EzSystemsTweetFieldTypeBundle.php
+Resources
+```
+
+Feel free to delete the Controller folder, since you won’t use it in this tutorial. It could have been useful, had our Field Type required an interface of its own.
+
+------------------------------------------------------------------------
+
+⬅ Previous: [Build the bundle](build_the_bundle.md)
+
+Next: [Structure the bundle](structure_the_bundle.md) ➡

--- a/docs/tutorial/creating_a_tweet_fieldtype.md
+++ b/docs/tutorial/creating_a_tweet_fieldtype.md
@@ -1,0 +1,68 @@
+# Creating a Tweet Field Type
+
+### Getting the code
+
+The code created in this tutorial is available on GitHub: (https://github.com/ezsystems/TweetFieldTypeBundle).
+
+This tutorial covers the creation and development of a custom eZ Platform [Field Type](https://doc.ez.no/display/DEVELOPER/Field+Types+reference).
+Field Types are the smallest building blocks of content. eZ Platform comes with about [30 native types](https://doc.ez.no/display/DEVELOPER/Field+Types+reference) that cover most common needs (Text line, Rich text, Email, Author list, Content relation, Map location, Float, etc.)
+
+Field Types are responsible for:
+
+- Storing data, either using the native storage engine mechanisms or specific means
+- Validating input data
+- Making the data searchable (if applicable)
+- Displaying Fields of this type
+
+Custom Field Types are a very powerful type of extension, since they allow you to hook deep into the content model.
+
+You can find the in-depth [documentation about Field Types and their best practices here](https://doc.ez.no/display/DEVELOPER/Field+Type+API+and+best+practices). It describes how each component of a Field Type interacts with the various layers of the system, and how to implement those.
+
+## Intended audience
+
+This tutorial is aimed at developers who are familiar with eZ Platform and are comfortable with operating in PHP and Symfony2.
+
+## Content of the tutorial
+
+This tutorial will demonstrate how to create a Field Type on the example of a *Tweet* Field Type. It will:
+
+- Accept as input the URL of a tweet (https://twitter.com/{username}/status/{id})
+- Fetch the tweet using the Twitter oEmbed API (https://dev.twitter.com/docs/embedded-tweets)
+- Store the tweet’s embed contents and URL
+- Display the tweet's embedded version when displaying the field from a template
+
+## Preparation
+
+To start the tutorial, you need to make a clean eZ Platform installation. Follow the guide for your system from [Step 1: Installation](https://doc.ez.no/display/DEVELOPER/Step+1%3A+Installation). Remember to install using the `dev` environment.
+
+## Steps
+
+The tutorial will lead you through the following steps:
+
+#### 1. The bundle
+
+Field Types, like any other eZ Platform plugin, must be provided as Symfony2 bundles. This chapter covers the creation and organization of this bundle.
+Read more about [creating](create_the_bundle.md) and [structuring the bundle](structure_the_bundle.md).
+
+#### 2. API
+
+This part covers the implementation of the eZ Platform API elements required to implement a custom Field Type.
+Read more about [implementing the Tweet\\Value class](implement_the_tweet_value_class.md) and [the Tweet\\Type class](implement_the_tweet_type_class.md).
+
+#### 3. Converter
+
+Storing data from any Field Type in the Legacy Storage Engine requires that your custom data is mapped to the data model.
+Read more about [implementing the Legacy Storage Engine Converter](implement_the_legacy_storage_engine_converter.md).
+
+#### 4. Templating
+
+Displaying a Field Type's data is done through a [Twig template](http://twig.sensiolabs.org/doc/intro.html).
+Read more about [implementing the Field Type template](introduce_a_template.md).
+
+#### 5. PlatformUI integration
+
+Viewing and editing values of the Field Type in PlatformUI requires that you extend PlatformUI, using mostly JavaScript.
+
+You should ideally read the general [extensibility documentation for PlatformUI](https://doc.ez.no/display/DEVELOPER/Extending+eZ+Platform+UI). You can find information about view templates [in the next tutorial](https://doc.ez.no/display/DEVELOPER/Define+a+View). Edit templates are not documented at the time of writing, but [Netgen](http://www.netgenlabs.com/) has published a tutorial that covers the topic: (http://www.netgenlabs.com/Blog/Adding-support-for-a-new-field-type-to-eZ-Publish-Platform-UI).
+
+[Start the tutorial](build_the_bundle.md) ➡

--- a/docs/tutorial/implement_the_legacy_storage_engine_converter.md
+++ b/docs/tutorial/implement_the_legacy_storage_engine_converter.md
@@ -1,0 +1,149 @@
+# Implement the Legacy Storage Engine Converter
+
+So far, your Field Type’s value is represented by the `Tweet\Value` class. It holds a semantic representation of the type’s data: a URL, author URL and the tweet's content.
+
+The next step is to tell the system how to actually *store* this.
+
+## About converters
+
+Unlike eZ Publish Legacy, eZ Platform supports (by design) multiple storage engines. The main, and almost only one right now is the Legacy Storage Engine, based on the legacy database, with a new implementation. Since each storage engine may have its own way of storing data, you need to map each Field Type value to something legacy can understand.
+
+We will implement a Field Type Converter, each storage engine defining its own interface for those.
+
+## Legacy Field Type converters
+
+The legacy storage engine uses the `ezcontentobject_attribute` table to store Field values, and `ezcontentclass_attribute` to store Field definition values (settings, etc.). They are both based on the same principle.
+
+Each row represents a Field or a FieldDefinition, and offers several free fields, of different types, where the type can store its data:
+
+- `ezcontentobject_attribute` offers 3 fields for this purpose:
+    - `data_int`
+    - `data_text`
+    - `data_float`
+- `ezcontentclass_attribute` offers a few more:
+    - four `data_int` (`data_int1` to `data_int4`) fields
+    - four `data_float` (`data_float1` to `data_float4`) ones
+    - five `data_text` (`data_text1` to `data_text5`)
+
+Each type is free to use those fields in any way it requires. Converters will map a Field’s semantic values to the fields described above, for both settings (validation + configuration) and value.
+
+## Implementing Tweet\\LegacyConverter
+
+The Converter will be placed alongside the Type and Value definitions (the kernel stores them inside the Legacy Storage Engine structure): `eZ/Publish/FieldType/Tweet/LegacyConverter.php` .
+
+A Legacy Converter must implement the `eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter` interface:
+
+``` php
+// TweetFieldTypeBundle/eZ/Publish/FieldType/Tweet/LegacyConverter.php
+
+<?php
+namespace EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet;
+
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
+
+class LegacyConverter implements Converter
+{
+}
+```
+
+The Converter interface expects you to implement 5 methods:
+
+- `toStorageValue()` and `toFieldValue()`
+    used to convert an API field value to a legacy storage value, and a legacy storage value to an API field value.  
+
+- `toStorageFieldDefinition()` and `toFieldDefinition()`
+    used to convert a field definition to a legacy one, and a stored legacy field definition to an API field definition.
+
+- `getIndexColumn()`
+    tell the API which legacy DB field should be used to sort & filter content, either `sort_key_string` or `sort_key_int`.
+
+### Implementing Field Value converters: toFieldValue() and toStorageValue()
+
+As said above, those two methods are used to convert from a Field to a value that Legacy can store, and the other way around.
+
+You have defined that you wanted to store the tweet’s URL in `data_text`, and that sorting would be done on the `username-status-tweetid` string you extract in `getName()` and `getSortInfo()`.
+
+`toStorageValue()` will fill the provided `eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue` from a `Tweet\Value`, while `toFieldValue()` will do the exact opposite:
+
+``` php
+// TweetFieldTypeBundle/eZ/Publish/FieldType/Tweet/LegacyConverter.php
+
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
+use eZ\Publish\SPI\Persistence\Content\FieldValue;
+
+// [...]
+
+public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
+{
+    $storageFieldValue->dataText = json_encode($value->data);
+    $storageFieldValue->sortKeyString = $value->sortKey;
+}
+
+public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue)
+{
+    $fieldValue->data = json_decode($value->dataText, true);
+    $fieldValue->sortKey = $value->sortKeyString;
+}
+```
+
+With these two methods, the legacy storage engine is able to convert a `Tweet\Value` into legacy data, and legacy data back into a `Tweet\Value` object.
+
+### Implementing Field Definition converters: `toStorageFieldDefinition()` and `toFieldDefinition()`
+
+The first two methods you have implemented apply to a Field’s value, but you also need to convert your Field’s definition. For example, a TextLine’s max length, or any FieldDefinition option.
+
+This is done using `toStorageDefinition()` that converts a `FieldDefinition` into a `StorageFieldDefinition`. `toFieldDefinition()` does the opposite. In this case, you actually don’t need to implement those methods since your Tweet Type doesn’t have settings:
+
+``` php
+// TweetFieldTypeBundle/eZ/Publish/FieldType/Tweet/LegacyConverter.php
+
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+
+// [...]
+
+public function toStorageFieldDefinition( FieldDefinition $fieldDef, StorageFieldDefinition $storageDef )
+{
+}
+
+public function toFieldDefinition( StorageFieldDefinition $storageDef, FieldDefinition $fieldDef )
+{
+}
+```
+
+### Implementing `getIndexColumn()`
+
+In `toFieldValue()` and `toStorageValue()` you have used the `sortKeyString` property from `StorageFieldValue`. `getIndexColumn()` will tell provide the legacy storage engine with the type of index / sort column it should use: string (`sort_key_string`) or int (`sort_key_int`). Depending on which one is returned, the system will either use the `sortKeyString` or the `sortKeyInt` properties from the `StorageFieldValue`.
+
+``` php
+// TweetFieldTypeBundle/eZ/Publish/FieldType/Tweet/LegacyConverter.php
+
+public function getIndexColumn()
+{
+   return 'sort_key_string';
+}
+```
+
+## Registering the converter
+
+Just like a Type, a Legacy Converter needs to be registered and tagged in the service container.
+
+The tag is `ezpublish.storageEngine.legacy.converter`, and it requires an `alias` attribute to be set to the Field Type identifier (`eztweet`). Add this block to `Resources/config/services.yml`:
+
+``` yml
+# Resources/config/services.yml
+
+services:
+# declaration of the Fieldtype service
+# ...
+    ezsystems.tweetbundle.fieldtype.eztweet.converter:
+        class: EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\LegacyConverter
+        tags:
+    - {name: ezpublish.storageEngine.legacy.converter, alias: eztweet}
+```
+
+------------------------------------------------------------------------
+
+⬅ Previous: [Register the Field Type as a service](register_the_fieldtype_as_a_service.md)
+
+Next: [Introduce a template](introduce_a_template.md) ➡

--- a/docs/tutorial/implement_the_tweet_type_class.md
+++ b/docs/tutorial/implement_the_tweet_type_class.md
@@ -1,0 +1,434 @@
+# Implement the Tweet\\Type class
+
+As said in the introduction, the Type class of a Field Type must implement `eZ\Publish\SPI\FieldType\FieldType` (later referred to as "Field Type interface").
+
+All native Field Types also extend the `eZ\Publish\Core\FieldType\FieldType` abstract class that implements this interface and provides implementation facilities through a set of abstract methods of its own. In this case, Type classes implement a mix of methods from the Field Type interface and from the abstract Field Type.
+
+Let’s go over those methods and their implementation.
+
+### Identification method
+
+#### `getFieldTypeIdentifier()`
+
+This method must return the string that **uniquely** identifies this Field Type (DataTypeString in legacy), in this case "`eztweet`":
+
+``` php
+// eZ/Publish/FieldType/Tweet/Type.php
+
+public function getFieldTypeIdentifier()
+{
+   return 'eztweet';
+}
+```
+
+### Value handling methods
+
+#### `createValueFromInput()` and `checkValueStructure()`
+
+Both methods are used by the abstract Field Type implementation of `acceptValue()`. This Field Type interface method checks and transforms various input values into the type's own Value class: `eZ\FieldType\Tweet\Value`. This method must:
+
+- either **return the Value object** it was able to create out of the input value,
+- or **return this value untouched**. The API will detect this and inform that the input value was not accepted.
+
+The only acceptable value for your type is the URL of a tweet (you could of course imagine more possibilities). This should do:
+
+``` php
+protected function createValueFromInput( $inputValue )
+{
+   if ( is_string( $inputValue ) )
+   {
+       $inputValue = new Value( array( 'url' => $inputValue ) );
+   }
+
+   return $inputValue;
+}
+```
+
+Use this method to provide convenient ways to set an attribute’s value using the API. This can be anything from primitives to complex business objects.
+
+Next, implement `checkValueStructure()`. It is called by the abstract Field Type to ensure that the Value fed to the Type is acceptable. In this case, you want to be sure that `Tweet` `     \Value::$url` is a string:
+
+``` php
+protected function checkValueStructure( BaseValue $value )
+{
+   if ( !is_string( $value->url ) )
+   {
+       throw new eZ\Publish\Core\Base\Exceptions\InvalidArgumentType(
+           '$value->url',
+           'string',
+           $value->url
+       );
+   }
+}
+```
+
+You see that this executes the same check as in `createValueFromInput()`, but both methods aren't responsible for the same thing. The first will, *if given something else than a Value of its type*, try to convert it to one. `checkValueStructure()` will always be used, even if the Field Type is directly fed a `Value` object, and not a string.
+
+### Value initialization
+
+#### `getEmptyValue()`
+
+This method provides what is considered an empty value of this type, depending on your business requirements. No extra initialization is required in this case.
+
+``` php
+// eZ/Publish/FieldType/Tweet/Type.php
+
+public function getEmptyValue()
+{
+   return new Value;
+}
+```
+
+If you ran the unit tests at this point, you would get about five failures, all of them on the `fromHash()` or `toHash()` methods. You'll handle them later.
+
+### Validation methods
+
+#### `validateValidatorConfiguration()` and `validate()`
+
+The Type class is also responsible for validating input data (to a `Field`), as well as configuration input data (to a `FieldDefinition`). In this tutorial, we will run two validation operations on input data:
+
+- validate submitted urls, ensuring they actually reference a Twitter status;
+- limit input to a known list of authors, as an optional validation step.
+
+`validateValidatorConfiguration()` will be called when an instance of the Field Type is added to a Content Type, to ensure that the validator configuration is valid.
+
+For the validator schema configuration, you can add:
+
+``` php
+// eZ/Publish/FieldType/Tweet/Type.php
+
+protected $validatorConfigurationSchema = array(
+    'TweetUrlValidator' => array(),
+    'TweetAuthorValidator' => array(
+            'AuthorList' => array(
+                 'type' => 'array',
+                 'default' => array()
+        )
+    )
+);
+```
+
+For a TextLine (length validation), it means checking that both min length and max length are positive integers, and that min is lower than max.
+
+When an instance of the type is added to a Content Type, `validateValidatorConfiguration()` receives the configuration for the validators used by the Type as an array. It must return an array of error messages if errors are found in the configuration, and an empty array if no errors were found.
+
+For TextLine, the provided array looks like this:
+
+``` php
+// eZ/Publish/FieldType/Tweet/Type.php
+
+array(
+   'StringLengthValidator' => array(
+       'minStringLength' => 0,
+       'maxStringLength' => 100
+   )
+);
+```
+
+The structure of this array is totally free, and up to each type implementation. In this tutorial it will mimic what is done in native Field Types:
+
+Each level one key is the name of a validator, as acknowledged by the Type. That key contains a set of parameter name / parameter value rows. You must check that:
+
+- all the validators in this array are known to the type
+- arguments for those validators are valid and have sane values
+
+You do not need to include mandatory validators if they don’t have options. Here is an example of what your Type expects as validation configuration:
+
+``` php
+array(
+   ‘TweetAuthorValidator’ => array(
+       ‘AuthorList’ => array( ‘johndoe’, ‘janedoe’ )
+   )
+);
+```
+
+The configuration says that tweets must be either by `johndoe` or by `janedoe`. If you had not provided `TweetAuthorValidator` at all, it would have been ignored.
+
+You will iterate over the items in `$validatorConfiguration` and:
+
+- add errors for those you don’t know about;
+- check that provided arguments are known and valid:
+  - `TweetAuthorValidator` accepts a non-empty array of valid Twitter usernames
+
+``` php
+// eZ/Publish/FieldType/Tweet/Type.php
+
+public function validateValidatorConfiguration( $validatorConfiguration )
+{
+    $validationErrors = array();
+    foreach ($validatorConfiguration as $validatorIdentifier => $constraints) {
+        // Report unknown validators
+        if ($validatorIdentifier !== 'TweetValueValidator') {
+            $validationErrors[] = new ValidationError("Validator '$validatorIdentifier' is unknown");
+            continue;
+        }
+        // Validate arguments from TweetValueValidator
+        foreach ($constraints as $name => $value) {
+            switch ($name) {
+                case 'authorList':
+                    if (!is_array($value)) {
+                        $validationErrors[] = new ValidationError("Invalid authorList argument");
+                    }
+
+                    foreach ($value as $authorName) {
+                        if (!preg_match('/^[a-z0-9_]{1,15}$/i', $authorName)) {
+                            $validationErrors[] = new ValidationError("Invalid twitter username");
+                        }
+                    }
+                    break;
+                default:
+                    $validationErrors[] = new ValidationError("Validator parameter '$name' is unknown");
+            }
+        }
+    }
+    return $validationErrors;
+}
+```
+
+`validate()` is the method that runs the actual validation on data, when a Content item is created with a Field of this type:
+
+``` php
+// eZ/Publish/FieldType/Tweet/Type.php
+
+/**
+ * Validates a field based on the validators in the field definition.
+ *
+ * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+ *
+ * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+ * The field definition of the field
+ * @param Value $fieldValue The field value for which an action is performed
+ *
+ * @return \eZ\Publish\SPI\FieldType\ValidationError[]
+ */
+    public function validate(FieldDefinition $fieldDefinition, SPIValue $fieldValue)
+    {
+        $errors = [];
+        if ($this->isEmptyValue($fieldValue)) {
+            return $errors;
+        }
+        // Tweet Url validation
+        if (!preg_match('#^https?://twitter.com/([^/]+)/status/[0-9]+$#', $fieldValue->url, $m)) {
+            $errors[] = new ValidationError(
+                'Invalid twitter status url %url%',
+                null,
+                ['%url%' => $fieldValue->url]
+            );
+            return $errors;
+        }
+        $author = $m[1];
+        $validatorConfiguration = $fieldDefinition->getValidatorConfiguration();
+        if (!$this->isAuthorApproved($author, $validatorConfiguration)) {
+            $errors[] = new ValidationError(
+                'Twitter user %user% is not in the approved author list',
+                null,
+                ['%user%' => $m[1]]
+            );
+        }
+        return $errors;
+    }
+```
+
+First, you validate the URL with a regular expression. If it doesn’t match, you add an instance of `ValidationError` to the return array. Note that the tested value isn’t directly embedded in the message but passed as an argument. This ensures that the variable is properly encoded in order to prevent attacks, and allows for singular/plural phrases using the second parameter.
+
+Then, if your Field Type instance’s configuration contains a `TweetValueValidator` key, you will check that the username in the status URL matches one of the valid authors.
+
+### Metadata handling methods
+
+#### `getName()` and `getSortInfo()`
+
+Field Types require two methods related to Field metadata:
+
+- ` getName()` is used to generate a name out of a Field value, either to name a Content item (naming pattern in legacy) or to generate a part for a URL alias.
+
+- ` getSortInfo()` is used by the persistence layer to obtain the value it can use to sort and filter on a Field of this type
+
+Obviously, a tweet’s full URL isn’t really suitable as a name. Let’s use a subset of it: `<username>-<tweetId>` should be reasonable enough, and suitable for both sorting and naming.
+
+You can assume that this method will not be called if the Field is empty, and that the URL is a valid twitter URL:
+
+``` php
+public function getName( SPIValue $value )
+{
+   return preg_replace(
+       '#^https?://twitter\.com/([^/]+)/status/([0-9]+)$#',
+       '$1-$2',
+       (string)$value->url );
+}
+
+protected function getSortInfo(CoreValue $value)
+{
+    return (string)$value->url;
+}
+```
+
+In `getName()` you run a regular expression replace on the URL to extract the part you’re interested in.
+
+This name is a perfect match for `getSortInfo()` as it allows you to sort by the tweet’s author and by the tweet’s ID.
+
+### Field Type serialization methods
+
+#### `fromHash()` and `toHash()`
+
+Both methods defined in the Field Type interface are core to the REST API. They are used to export values to serializable hashes.
+
+In this case it is quite easy:
+
+- `toHash()` will build a hash with every property from `Tweet\Value`;
+
+- `fromHash()` will instantiate a `Tweet\Value` with the hash it receives.  
+
+``` php
+public function fromHash( $hash )
+{
+   if ( $hash === null )
+   {
+       return $this->getEmptyValue();
+   }
+   return new Value( $hash );
+}
+
+public function toHash(SPIValue $value)
+{
+    if ($this->isEmptyValue($value)) {
+        return null;
+    }
+    return [
+        'url' => $value->url,
+        'authorUrl' => $value->authorUrl,
+        'contents' => $value->contents
+    ];
+}
+```
+
+### Persistence methods
+
+#### `fromPersistenceValue()` and `toPersistenceValue()`
+
+Storage of Field Type data is done through the persistence layer (SPI).
+
+Field Types use their own Value objects to expose their contents using their own domain language. However, to store those objects, the Type needs to map this custom object to a structure understood by the persistence layer: `PersistenceValue`. This simple value object has three properties:
+
+- `data` – standard data, stored using the storage engine's native features
+- `externalData` – external data, stored using a custom storage handler
+- `sortKey` – sort value used for sorting
+
+The role of those mapping methods is to convert a `Value` of the Field Type into a `PersistenceValue` and the other way around.
+
+##### About external storage
+
+Whatever is stored in `externalData` requires an external storage handler to be written. Read more about external storage in [Field Type API and best practices](https://doc.ez.no/display/DEVELOPER/Field+Type+API+and+best+practices).
+
+External storage is beyond the scope of this tutorial, but many examples can be found in existing Field Types.
+
+You will follow a simple implementation here: the `Tweet\Value` object will be serialized as an array to the `code` property using `fromHash()` and `toHash()`:
+
+``` php
+// Tweet\\Type
+
+/**
+ * @param \EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\Value $value
+ * @return \eZ\Publish\SPI\Persistence\Content\FieldValue
+ */
+public function toPersistenceValue(SPIValue $value)
+{
+    if ($value === null) {
+        return new PersistenceValue(
+            [
+                'data' => null,
+                'externalData' => null,
+                'sortKey' => null,
+            ]
+        );
+    }
+    return new PersistenceValue(
+        [
+            'data' => $this->toHash($value),
+            'sortKey' => $this->getSortInfo($value),
+        ]
+    );
+}
+/**
+ * @param \eZ\Publish\SPI\Persistence\Content\FieldValue $fieldValue
+ * @return \EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\Value
+ */
+public function fromPersistenceValue( PersistenceValue $fieldValue )
+{
+    if ( $fieldValue->data === null )
+    {
+        return $this->getEmptyValue();
+    }
+    return new Value( $fieldValue->data );
+}
+```
+
+## Fetching data from the Twitter API
+
+As explained in the tutorial's introduction, you will enrich our tweet's URL with the embed version, fetched using the Twitter API. To do so, you will, when `toPersistenceValue()` is called, fill in the value's contents property from this method, before creating the `PersistenceValue` object.
+
+First, we need a Twitter client in `Tweet\Type`. For convenience, one is provided in this tutorial's bundle:
+
+- the `Twitter\TwitterClient` class
+- the `Twitter\TwitterClientInterface` interface
+- an `ezsystems.tweetbundle.twitter.client` service that uses the class above.
+
+The interface has one method: `getEmbed( $statusUrl )` that, given a tweet's URL, returns the embed code as a string. The implementation is very simple, for the sake of simplicity, but gets the job done. Ideally, it should at the very least handle errors, but it is not necessary here.
+
+## Injecting the Twitter client into `Tweet\Type`
+
+Your Field Type doesn't have a constructor yet. You will create one, with an instance of `Twitter\TwitterClientInterface` as the argument, and store it in a new protected property:
+
+``` php
+// eZ/Publish/FieldType/Tweet/Type.php:
+
+use EzSystems\TweetFieldTypeBundle\Twitter\TwitterClientInterface;
+
+class Type extends FieldType
+{
+    /** @var TwitterClientInterface */
+    protected $twitterClient;
+
+    public function __construct( TwitterClientInterface $twitterClient )
+    {
+        $this->twitterClient = $twitterClient;
+    }
+}
+```
+
+## Completing the value using the Twitter client
+
+As described above, before creating the `PersistenceValue` object in `toPersistenceValue`, you will fetch the tweet's embed contents using the client, and assign it to `Tweet\Value::$data`:
+
+``` php
+// eZ/Publish/FieldType/Tweet/Type.php
+
+    public function toPersistenceValue(SPIValue $value)
+    {
+        if ($value === null) {
+            return new PersistenceValue(
+                [
+                    'data' => null,
+                    'externalData' => null,
+                    'sortKey' => null,
+                ]
+            );
+        }
+        if ($value->contents === null) {
+            $value->contents = $this->twitterClient->getEmbed($value->url);
+        }
+        return new PersistenceValue(
+            [
+                'data' => $this->toHash($value),
+                'sortKey' => $this->getSortInfo($value),
+            ]
+        );
+    }
+```
+
+And that's it! When the persistence layer stores content from our type, the value will be completed with what the twitter API returns.
+
+------------------------------------------------------------------------
+
+⬅ Previous: [Implement the Tweet\\Value class](implement_the_tweet_value_class.md)
+
+Next: [Register the Field Type as a service](register_the_fieldtype_as_a_service.md) ➡

--- a/docs/tutorial/implement_the_tweet_value_class.md
+++ b/docs/tutorial/implement_the_tweet_value_class.md
@@ -1,0 +1,65 @@
+# Implement the Tweet\\Value class
+
+The Value class of a Field Type is by design very simple. It is meant to be stateless and as lightweight as possible. This class must contain as little logic as possible, because the logic is the responsibility of the Type class. You will create this Type class in the next step.
+
+All the code for the Bundle will be created in: `src/EzSystems/TweetFieldTypeBundle`
+
+The Value class will contain at least:
+
+- public properties: used to store the actual data
+- an implementation of the `__toString()` method: required by the Value interface it inherits from
+
+By default, the constructor from `FieldType\Value` will be used. It allows you to pass a hash of property/value pairs. You can override it as well if you want.
+
+The Tweet Field Type is going to store 3 elements:
+
+- The tweet’s URL
+- The tweet’s author URL
+- The body, as an HTML string  
+
+At this point, it does not matter where they are stored. All you care about is *what you want your Field Type to expose as an API*.
+
+You will end up with the following properties:
+
+``` php
+// eZ/Publish/FieldType/Tweet/Value.php
+
+//Properties of the class Value
+/**
+* Tweet URL on twitter.com (http://twitter.com/UserName/status/id).
+* @var string
+*/
+public $url;
+
+
+/**
+* Author's tweet URL (http://twitter.com/UserName)
+* @var string
+*/
+public $authorUrl;
+
+
+/**
+* The tweet's embed HTML
+* @var string
+*/
+public $contents;
+```
+
+The only thing left to honor the `FieldType\Value` interface is to add a `__toString()` method, in addition to the constructor. Let’s say that yours will return the tweet’s URL:
+
+``` php
+// eZ/Publish/FieldType/Tweet/Value.php
+
+//Methods of the class Value
+public function __toString()
+{
+   return (string)$this->url;
+}
+```
+
+------------------------------------------------------------------------
+
+⬅ Previous: [Structure the bundle](structure_the_bundle.md)
+
+Next: [Implement the Tweet\\Type class](implement_the_tweet_type_class.md) ➡

--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -1,0 +1,12 @@
+# Tutorial : Creating a Tweet Fieldtype
+
+
+* [Introduction](creating_a_tweet_fieldtype.md)
+* [Build the bundle](build_the_bundle.md)
+*    [Step 1: Create the bundle](create_the_bundle.md)
+*    [Step 2: Structure the bundle](structure_the_bundle.md)
+* [Step 3: Implement the Tweet\Value class](implement_the_tweet_value_class.md)
+* [Step 4: Implement the Tweet\Type class](implement_the_tweet_type_class.md)
+* [Step 5: Register the Field Type as a service](register_the_fieldtype_as_a_service.md)
+* [Step 6: Implement the Legacy Storage Engine Converter](implement_the_legacy_storage_engine_converter.md)
+* [Step 7: Introduce a template](introduce_a_template.md)

--- a/docs/tutorial/introduce_a_template.md
+++ b/docs/tutorial/introduce_a_template.md
@@ -1,0 +1,109 @@
+# Introduce a template
+
+In order to display data of your Field Type from templates, you need to create and register a template for it. You can find documentation about [FieldType templates](https://doc.ez.no/display/DEVELOPER/Field+Type+template), as well as on [importing settings from a bundle](https://doc.ez.no/display/DEVELOPER/Importing+settings+from+a+bundle).
+
+In short, such a template must:
+
+- extend `EzPublishCoreBundle::content_fields.html.twig`
+- define a dedicated Twig block for the type, named by convention `<TypeIdentifier_field>`, in this case, `eztweet_field`
+- be registered in parameters
+
+## The template:` Resources/views/fields/eztweet.html.twig`
+
+The first thing to do is create the template. It will basically define the default display of a tweet. Remember that [field type templates can be overridden](https://confluence.ez.no/display/DEVELOPER/ez_render_field#ez_render_field-Overrideafieldtemplateblock) in order to tweak what is displayed and how.
+
+Each Field Type template receives a set of variables that can be used to achieve the desired goal. The variable you care about is `field`, an instance of `eZ\Publish\API\Repository\Values\Content\Field`. In addition to its own metadata (`id`, `fieldDefIdentifier`, etc.), it exposes the Field Value (`Tweet\Value`) through the `value` property.
+
+This would work as a primitive template:  
+
+``` html
+{# TweetFieldTypeBundle/Resources/views/fields/eztweet.html.twig #}
+
+{% extends "EzPublishCoreBundle::content_fields.html.twig" %}
+
+{% block eztweet_field %}
+{% spaceless %}
+    {{ field.value.contents|raw }}
+{% endspaceless %}
+{% endblock %}
+```
+
+`field.value.contents` is piped through the `raw` twig operator, since the variable contains HTML code. Without it, the HTML markup would be visible directly, since twig escapes variables by default. Notice that the code is nested within a `spaceless` tag, so that you can format the template in a readable manner without jeopardizing the display with unwanted spaces.
+
+### Using the content field helpers
+
+Even though the above will work just fine, a few helpers will enable you to get something a bit more flexible. The <a href="https://github.com/ezsystems/ezpublish-kernel/blob/master/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig">EzPublishCoreBundle::content_fields.html.twig</a> template, where the native Field Type templates are implemented, provides a few helpers: `simple_block_field`, `simple_inline_field` and `field_attributes`. The first two are used to display a field either as a block or inline. `field_attributes` makes it easier to use the `attr` variable that contains additional (HTML) attributes for the field.
+
+Let's try to display the value as a block element.
+
+First, you need to make the template inherit from `content_fields.html.twig`. Then, create a `field_value` variable that will be used by the helper to print out the content inside the markup. And that's it. The helper will use `field_attributes` to add the HTML attributes to the generated `div`.
+
+``` html
+{# TweetFieldTypeBundle/Resources/views/fields/eztweet.html.twig #}
+
+{% extends "EzPublishCoreBundle::content_fields.html.twig" %}
+
+{% block eztweet_field %}
+{% spaceless %}
+    {% set field_value %}
+        {{ field.value.contents|raw }}
+    {% endset %}
+    {{ block( 'simple_block_field' ) }}
+{% endspaceless %}
+{% endblock %}
+```
+
+`fieldValue` is set to the markup you had above, using a `{% set %}` block. You then call the `block` function to process the `simple_block_field` template block.
+
+## Registering the template
+
+As explained in the [FieldType template documentation](https://confluence.ez.no/display/DEVELOPER/Field+Type+template#FieldTypetemplate-Registeringyourtemplate), a Field Type template needs to be registered in the eZ Platform semantic configuration. The most basic way to do this would be to do so in `app/config/ezplatform.yml`:
+
+``` yml
+# app/config/ezplatform.yml
+
+ezpublish:
+    global:
+        field_templates:
+            - { template: "EzSystemsTweetFieldTypeBundle:fields:eztweet.html.twig"}
+```
+
+However, this is far from ideal. You want this to be part of our bundle, so that no manual configuration is required. For that to happen, you need to make the bundle extend the eZ Platform semantic configuration.
+
+To do so, you are going to make your Bundle's dependency injection extension (`DependencyInjection/EzSystemsTweetFieldTypeExtension.php`) implement `Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface`. This interface will let you prepend bundle configuration:
+
+``` php
+// TweetFieldTypeBundle/DependencyInjection/EzSystemsTweetFieldTypeExtension.php
+
+<?php
+use Symfony\Component\DependencyInjection\Extension\PrependExtensionInterface;
+use Symfony\Component\Yaml\Yaml;
+
+class EzSystemsTweetFieldTypeExtension extends Extension implements PrependExtensionInterface
+{
+    public function prepend(ContainerBuilder $container)
+    {
+        $config = Yaml::parse(file_get_contents(__DIR__.'/../Resources/config/ez_field_templates.yml'));
+        $container->prependExtensionConfig('ezpublish', $config);
+    }
+}
+```
+
+The last thing to do is move the template mapping from `app/config/ezplatform.yml` to `Resources/config/ezpublish_field_templates.yml`:
+
+``` yml
+# Resources/config/ezpublish\_field\_templates.yml
+
+system:
+    default:
+        field_templates:
+            - {template: EzSystemsTweetFieldTypeBundle:fields:eztweet.html.twig, priority: 0}
+```
+
+Notice that the `ezpublish` yaml block was deleted. This is because you already import your configuration under the `ezpublish` namespace in the `prepend` method.
+
+You should now be able to display a Content item with this Field Type from the front office, with a fully functional embed.
+
+------------------------------------------------------------------------
+
+⬅ Previous: [Implement the Legacy Storage Engine Converter](implement_the_legacy_storage_engine_converter.md)

--- a/docs/tutorial/register_the_fieldtype_as_a_service.md
+++ b/docs/tutorial/register_the_fieldtype_as_a_service.md
@@ -1,0 +1,59 @@
+# Register the Field Type as a service
+
+To complete the implementation, you must register your Field Type with Symfony by creating a service for it.
+
+Services are by default declared by bundles in `Resources/config/services.yml`.
+
+##### Using a dedicated file for the Field Type services
+
+In order to be closer to the kernel best practices, you could declare your Field Type services in a custom `fieldtypes.yml` file.
+
+All you have to do is instruct the bundle to actually load this file in addition to `services.yml` (or instead of `services.yml`!). This is done in the extension definition file, `DependencyInjection/EzSystemsTweetFieldTypeExtension.php`, in the `load()` method.
+
+Inside this file, find this line:
+
+``` php
+$loader->load('services.yml');
+```
+
+This is where your bundle tells Symfony that when parameters are loaded, `services.yml` should be loaded from `Resources/config/` (defined above). Either replace the line, or add a new one with:
+
+``` php
+$loader->load('fieldtypes.yml');
+```
+
+Like most API components, Field Types use the [Symfony 2 service tag mechanism](http://symfony.com/doc/current/components/dependency_injection/tags.html).
+
+The principle is quite simple: a service can be assigned one or several tags, with specific parameters. When the dependency injection container is compiled into a PHP file, tags are read by `CompilerPass` implementations that add extra handling for tagged services. Each service tagged as `ezpublish.fieldType` is added to a [registry](http://martinfowler.com/eaaCatalog/registry.html) using the alias argument as its unique identifier (`ezstring`, `ezxmltext`, etc.). Each Field Type must also inherit from the abstract `ezpublish.fieldType` service. This ensures that the initialization steps shared by all Field Types are executed.
+
+Here is the service definition for your Tweet type:
+
+``` php
+// **Resources/config/services.yml**
+
+services:
+    ezsystems.tweetbundle.twitter.client:
+    class: EzSystems\TweetFieldTypeBundle\Twitter\TwitterClient
+```
+
+You take care of namespacing your Field Type with your vendor and bundle name to limit the risk of naming conflicts.
+
+And you can create a YAML file dedicated to the Bundle
+
+``` php
+// **Resources/config/fieldtypes.yml**
+
+services:
+    ezsystems.tweetbundle.fieldtype.eztweet:
+        parent: ezpublish.fieldType
+        class: EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\Type
+        tags:
+            - {name: ezpublish.fieldType, alias: eztweet}
+        arguments: ['@ezsystems.tweetbundle.twitter.client']
+```
+
+------------------------------------------------------------------------
+
+⬅ Previous: [Implement the Tweet\\Type class](implement_the_tweet_type_class.md)
+
+Next: [Implement the Legacy Storage Engine Converter](implement_the_legacy_storage_engine_converter.md) ➡

--- a/docs/tutorial/structure_the_bundle.md
+++ b/docs/tutorial/structure_the_bundle.md
@@ -1,0 +1,37 @@
+# Structure the bundle
+
+At this point, you have a basic application-specific Symfony 2 bundle. Let’s start by creating the structure for your Field Type.
+
+To make it easier to move around the code, you will to some extent mimic the structure that is used in the kernel of eZ Platform. Native Field Types are located inside `ezpublish-kernel` (in `vendor/ezsystems`), in the `eZ/Publish/Core/FieldType` folder.
+Each Field Type has its own subfolder: `TextLine`, `Email`, `Url`, etc.
+
+Clone this GitHub repository to follow this tutorial, it will be useful: (https://github.com/ezsystems/TweetFieldTypeBundle).
+
+You will use a structure quite close to this.
+
+From the tutorial git repository, list the contents of the `eZ/Publish/FieldType` folder:
+
+     eZ
+     └── Publish
+        └── FieldType
+            └── Tweet
+                ├── Type.php
+                └── Value.php
+
+A Field Type requires two base classes: `Type` and `Value`.
+
+### The Type class
+
+The Type contains the logic of the Field Type: validating data, transforming from various formats, describing the validators, etc.
+A Type class must implement `eZ\Publish\SPI\FieldType\FieldType`. It may also extend the `eZ\Publish\Core\FieldType\FieldType` abstract class.
+
+### The Value class
+
+The Value is used to represent an instance of our type within a Content item. Each Field will present its data using an instance of the Type’s Value class.
+A value class must implement the `eZ\Publish\SPI\FieldType\Value` interface. It may also extend the `eZ\Publish\Core\FieldType\Value` abstract class.
+
+------------------------------------------------------------------------
+
+⬅ Previous: [Create the bundle](create_the_bundle.md)
+
+Next: [Implement the Tweet\\Value class](implement_the_tweet_value_class.md) ➡


### PR DESCRIPTION
This PR adds missing documentation files to the missy branch, so it will be completely in sync with the master branch.
The documentation was added to the master branch in following PR: https://github.com/ezsystems/TweetFieldTypeBundle/pull/12.

I committed it as the fixup, so it can be easily squashed after merging.