### PR TITLE
EZP-27292: Fix the tagging helper

### DIFF
--- a/Resources/misc/tag-steps.sh
+++ b/Resources/misc/tag-steps.sh
@@ -1,32 +1,35 @@
 #!/bin/bash
 
 declare -a commits=(
-	"Create the bundle"
-	"Structure the bundle"
-	"Implement the Tweet\Value class"
-	"Implement the Tweet\Type class"
-	"Register the Field Type as a service"
-	"Implement the Legacy Storage Engine Converter"
-	"Add field view and field definition view templates"
-	)
+    "Create the bundle"
+    "Structure the bundle"
+    "Implement the Tweet\\\Value class"
+    "Implement the Tweet\\\Type class"
+    "Register the Field Type as a service"
+    "Implement the Legacy Storage Engine Converter"
+    "Add field view and field definition view templates"
+    )
 declare -a tags=(
-	"step1_create_the_bundle"
-	"step2_structure_the_bundle"
-	"step3_implement_the_tweet_value_class"
-	"step4_implement_the_tweet_type_class"
-	"step5_register_the_field_type_as_a_service"
-	"step6_implement_the_legacy_storage_engine_converter"
-	"step7_add_field_view_and_field_definition_view_templates"
-	)
+    "step1_create_the_bundle"
+    "step2_structure_the_bundle"
+    "step3_implement_the_tweet_value_class"
+    "step4_implement_the_tweet_type_class"
+    "step5_register_the_field_type_as_a_service"
+    "step6_implement_the_legacy_storage_engine_converter"
+    "step7_add_field_view_and_field_definition_view_templates"
+    )
 
 numberOfCommits=${#commits[@]}
 
 for (( i=0; i<${numberOfCommits}; i++ ));
 do
-	SHA1=`git log --oneline --all --grep "${commits[$i]}" | cut -d" " -f1`
-	git tag "${tags[$i]}" ${SHA1}
+    git tag -d "${tags[$i]}" 2> /dev/null
+    SHA1=`git log --oneline --grep "${commits[$i]}" | cut -d" " -f1`
+    if [ ${SHA1} ] ; then
+        git tag "${tags[$i]}" ${SHA1}
+    fi
 done
 
-git push --tags
+git push --tags --force
 
 echo "Tags created and pushed."


### PR DESCRIPTION
Current tagging helper is wrongly tagging third and fourth step. They are pointing to the last commit instead of the correct one. This is because of the backslashes used in the commit messages. 
I fixed the backslashes and I also made sure that if the commit cannot be found, the respective tag will not be placed anywhere. 
I also added the deletion of previous tags to the script to allow for tags reposition and I changed the line indentation to spaces instead of tabs, so it will be the same in the whole project.