### PR TITLE
EZP-27326: Use Nameable interface instead of deprecated getName function

### DIFF
--- a/Resources/config/fieldtypes.yml
+++ b/Resources/config/fieldtypes.yml
@@ -4,6 +4,7 @@ services:
         class: EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\Type
         tags:
             - {name: ezpublish.fieldType, alias: eztweet}
+            - {name: ezpublish.fieldType.nameable, alias: eztweet}
         arguments: ['@ezsystems.tweetbundle.twitter.client']
 
     ezsystems.tweetbundle.fieldtype.eztweet.converter:

--- a/Tests/eZ/Publish/FieldType/TweetTest.php
+++ b/Tests/eZ/Publish/FieldType/TweetTest.php
@@ -8,8 +8,10 @@
 
 namespace EzSystems\TweetFieldTypeBundle\Tests\eZ\Publish\FieldType;
 
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\FieldType\Tests\FieldTypeTest;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\SPI\FieldType\Value as SPIValue;
 use EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\Type as TweetType;
 use EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\Value as TweetValue;
 use EzSystems\TweetFieldTypeBundle\Twitter\TwitterClientInterface;
@@ -29,6 +31,11 @@ class TweetTest extends FieldTypeTest
      * @var \EzSystems\TweetFieldTypeBundle\Twitter\TwitterClientInterface|\PHPUnit_Framework_MockObject_MockObject
      */
     private $twitterClientMock;
+
+    /**
+     * @var FieldDefinition|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $fieldDefinitionMock;
 
     protected function createFieldTypeUnderTest()
     {
@@ -174,6 +181,19 @@ class TweetTest extends FieldTypeTest
         return 'eztweet';
     }
 
+    /**
+     * @dataProvider provideDataForGetName
+     *
+     * @param SPIValue $value
+     * @param string $expected
+     *
+     * @expectedException \RuntimeException
+     */
+    public function testGetName(SPIValue $value, $expected)
+    {
+        $this->getFieldTypeUnderTest()->getName($value);
+    }
+
     public function provideDataForGetName()
     {
         return [
@@ -261,12 +281,41 @@ class TweetTest extends FieldTypeTest
                 new TweetValue('https://test.com/user/status/123456789'),
                 [
                     new ValidationError(
-                        'Invalid twitter status url %url%',
+                        'Invalid Twitter status URL %url%',
                         null,
                         ['%url%' => 'https://test.com/user/status/123456789']
                     )
                 ]
             ]
         ];
+    }
+
+    /**
+     * @dataProvider provideDataForGetName
+     *
+     * @param SPIValue $value
+     * @param string $expected
+     */
+    public function testGetFieldName(SPIValue $value, $expected)
+    {
+        $fieldDefinitionMock = $this->getFieldDefinitionMock();
+        $languageCodeDummy = '';
+
+        self::assertSame(
+            $expected,
+            $this->getFieldTypeUnderTest()->getFieldName($value, $fieldDefinitionMock, $languageCodeDummy)
+        );
+    }
+
+    /**
+     * @return FieldDefinition|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function getFieldDefinitionMock()
+    {
+        if ($this->fieldDefinitionMock === null) {
+            $this->fieldDefinitionMock = $this->getMockBuilder(FieldDefinition::class)->getMock();
+        }
+
+        return $this->fieldDefinitionMock;
     }
 }

--- a/eZ/Publish/FieldType/Tweet/Type.php
+++ b/eZ/Publish/FieldType/Tweet/Type.php
@@ -49,10 +49,8 @@ class Type extends FieldType implements Nameable
      */
     public function getName(SPIValue $value)
     {
-        return preg_replace(
-            '#^https?://twitter\.com/([^/]+)/status/([0-9]+)$#',
-            '$1-$2',
-            (string)$value->url
+        throw new \RuntimeException(
+            'Name generation provided via NameableField set via "ezpublish.fieldType.nameable" service tag'
         );
     }
 
@@ -253,5 +251,21 @@ class Type extends FieldType implements Nameable
         return !isset($validatorConfiguration['TweetValueValidator'])
             || empty($validatorConfiguration['TweetValueValidator']['authorList'])
             || in_array($author, $validatorConfiguration['TweetValueValidator']['authorList']);
+    }
+
+    /**
+     * @param \EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\Value $value
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+     * @param string $languageCode
+     *
+     * @return string
+     */
+    public function getFieldName(SPIValue $value, FieldDefinition $fieldDefinition, $languageCode)
+    {
+        return preg_replace(
+            '#^https?://twitter\.com/([^/]+)/status/([0-9]+)$#',
+            '$1-$2',
+            (string)$value->url
+        );
     }
 }

--- a/eZ/Publish/FieldType/Tweet/Type.php
+++ b/eZ/Publish/FieldType/Tweet/Type.php
@@ -10,6 +10,7 @@ namespace EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet;
 
 use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\SPI\FieldType\Nameable;
 use eZ\Publish\SPI\Persistence\Content\FieldValue as PersistenceValue;
 use eZ\Publish\Core\FieldType\Value as CoreValue;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
@@ -17,7 +18,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use EzSystems\TweetFieldTypeBundle\Twitter\TwitterClientInterface;
 
-class Type extends FieldType
+class Type extends FieldType implements Nameable
 {
     /** @var TwitterClientInterface */
     protected $twitterClient;


### PR DESCRIPTION
Rebased changes from #9.

> JIRA : [EZP-27326](https://jira.ez.no/browse/EZP-27326)
Currently, Tweet FieldType uses getName() method for Content Items naming. This method is currently marked as deprecated and usage of Nameable interface is suggested instead.
Only a few core Field Types actually use Nameable interface right now, but I took them as examples.
I'm not 100% happy about testing (for example throwing RuntimeException in getName() method), but that's the way it is done in core.

Related documentation changes: #27.