### PR TITLE
EZP-27294: Add option to declare list of authors from which the tweets are allowed

### DIFF
--- a/Form/StringToArrayTransformer.php
+++ b/Form/StringToArrayTransformer.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * File containing the StringToArrayTransformer class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\TweetFieldTypeBundle\Form;
+
+use Symfony\Component\Form\DataTransformerInterface;
+
+/**
+ * DataTransformer that transforms array into comma-separated string and vice versa
+ */
+class StringToArrayTransformer implements DataTransformerInterface
+{
+    public function transform($array)
+    {
+        if ($array === null) {
+            return '';
+        }
+
+        return implode(',', $array);
+    }
+
+    public function reverseTransform($string)
+    {
+        if (empty($string)) {
+            return [];
+        }
+
+        $array = explode(',', $string);
+
+        return array_map('trim', $array);
+    }
+}

--- a/Resources/config/ez_field_templates.yml
+++ b/Resources/config/ez_field_templates.yml
@@ -4,3 +4,5 @@ system:
             - {template: EzSystemsTweetFieldTypeBundle:fields:eztweet.html.twig, priority: 0}
         fielddefinition_settings_templates:
             - {template: EzSystemsTweetFieldTypeBundle:platformui/content_type/view:eztweet.html.twig, priority: 0}
+        fielddefinition_edit_templates:
+            - {template: EzSystemsTweetFieldTypeBundle:platformui/content_type/edit:eztweet.html.twig, priority: 0}

--- a/Resources/config/fieldtypes.yml
+++ b/Resources/config/fieldtypes.yml
@@ -10,3 +10,8 @@ services:
         class: EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\LegacyConverter
         tags:
             - {name: ezpublish.storageEngine.legacy.converter, alias: eztweet}
+
+    ezsystems.tweetbundle.fieldtype.eztweet.form_mapper:
+        class: EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\FormMapper
+        tags:
+            - {name: ez.fieldFormMapper.definition, fieldType: eztweet}

--- a/Resources/misc/tag-steps.sh
+++ b/Resources/misc/tag-steps.sh
@@ -8,6 +8,7 @@ declare -a commits=(
     "Register the Field Type as a service"
     "Implement the Legacy Storage Engine Converter"
     "Add field view and field definition view templates"
+    "Add a validation"
     )
 declare -a tags=(
     "step1_create_the_bundle"
@@ -17,6 +18,7 @@ declare -a tags=(
     "step5_register_the_field_type_as_a_service"
     "step6_implement_the_legacy_storage_engine_converter"
     "step7_add_field_view_and_field_definition_view_templates"
+    "step8_add_a_validation"
     )
 
 numberOfCommits=${#commits[@]}

--- a/Resources/views/platformui/content_type/edit/eztweet.html.twig
+++ b/Resources/views/platformui/content_type/edit/eztweet.html.twig
@@ -1,0 +1,7 @@
+{% block eztweet_field_definition_edit %}
+    <div class="eztweet-validator author_list{% if group_class is not empty %} {{ group_class }}{% endif %}">
+        {{- form_label(form.authorList) -}}
+        {{- form_errors(form.authorList) -}}
+        {{- form_widget(form.authorList) -}}
+    </div>
+{% endblock %}

--- a/Tests/eZ/Publish/FieldType/TweetTest.php
+++ b/Tests/eZ/Publish/FieldType/TweetTest.php
@@ -9,6 +9,7 @@
 namespace EzSystems\TweetFieldTypeBundle\Tests\eZ\Publish\FieldType;
 
 use eZ\Publish\Core\FieldType\Tests\FieldTypeTest;
+use eZ\Publish\Core\FieldType\ValidationError;
 use EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\Type as TweetType;
 use EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet\Value as TweetValue;
 use EzSystems\TweetFieldTypeBundle\Twitter\TwitterClientInterface;
@@ -36,7 +37,14 @@ class TweetTest extends FieldTypeTest
 
     protected function getValidatorConfigurationSchemaExpectation()
     {
-        return [];
+        return [
+            'TweetValueValidator' => [
+                'authorList' => [
+                    'type' => 'array',
+                    'default' => []
+                ]
+            ]
+        ];
     }
 
     protected function getSettingsSchemaExpectation()
@@ -188,13 +196,77 @@ class TweetTest extends FieldTypeTest
 
     public function provideValidDataForValidate()
     {
-        // @todo implement me
-        return [];
+        return [
+            [
+                [
+                    'validatorConfiguration' => [
+                        'TweetValueValidator' => [
+                            'authorList' => ['user']
+                        ]
+                    ]
+                ],
+                new TweetValue('https://twitter.com/user/status/123456789')
+            ],
+            [
+                [
+                    'validatorConfiguration' => [
+                        'TweetValueValidator' => [
+                            'authorList' => ['anotherUser', 'user']
+                        ]
+                    ]
+                ],
+                new TweetValue('https://twitter.com/user/status/123456789')
+            ],
+            [
+                [
+                    'validatorConfiguration' => [
+                        'TweetValueValidator' => [
+                            'authorList' => []
+                        ]
+                    ]
+                ],
+                new TweetValue('https://twitter.com/user/status/123456789')
+            ]
+        ];
     }
 
     public function provideInvalidDataForValidate()
     {
-        // @todo implement me
-        return [];
+        return [
+            [
+                [
+                    'validatorConfiguration' => [
+                        'TweetValueValidator' => [
+                            'authorList' => ['anotherUser']
+                        ]
+                    ]
+                ],
+                new TweetValue('https://twitter.com/user/status/123456789'),
+                [
+                    new ValidationError(
+                        'Twitter user %user% is not in the approved author list',
+                        null,
+                        ['%user%' => 'user']
+                    )
+                ]
+            ],
+            [
+                [
+                    'validatorConfiguration' => [
+                        'TweetValueValidator' => [
+                            'authorList' => ['user']
+                        ]
+                    ]
+                ],
+                new TweetValue('https://test.com/user/status/123456789'),
+                [
+                    new ValidationError(
+                        'Invalid twitter status url %url%',
+                        null,
+                        ['%url%' => 'https://test.com/user/status/123456789']
+                    )
+                ]
+            ]
+        ];
     }
 }

--- a/Tests/eZ/Publish/FieldType/TweetTest.php
+++ b/Tests/eZ/Publish/FieldType/TweetTest.php
@@ -36,14 +36,7 @@ class TweetTest extends FieldTypeTest
 
     protected function getValidatorConfigurationSchemaExpectation()
     {
-        return [
-            'TweetValueValidator' => [
-                'authorList' => [
-                    'type' => 'array',
-                    'default' => []
-                ]
-            ]
-        ];
+        return [];
     }
 
     protected function getSettingsSchemaExpectation()

--- a/eZ/Publish/FieldType/Tweet/FormMapper.php
+++ b/eZ/Publish/FieldType/Tweet/FormMapper.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * File containing the FormMapper class.
+ *
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+
+namespace EzSystems\TweetFieldTypeBundle\eZ\Publish\FieldType\Tweet;
+
+use EzSystems\RepositoryForms\Data\FieldDefinitionData;
+use EzSystems\RepositoryForms\FieldType\FieldDefinitionFormMapperInterface;
+use EzSystems\TweetFieldTypeBundle\Form\StringToArrayTransformer;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormInterface;
+
+class FormMapper implements FieldDefinitionFormMapperInterface
+{
+    public function mapFieldDefinitionForm(FormInterface $fieldDefinitionForm, FieldDefinitionData $data)
+    {
+        $fieldDefinitionForm
+            ->add(
+                // Creating from FormBuilder as we need to add a DataTransformer.
+                $fieldDefinitionForm->getConfig()->getFormFactory()->createBuilder()
+                    ->create('authorList', TextType::class, [
+                        'required' => false,
+                        'property_path' => 'validatorConfiguration[TweetValueValidator][authorList]',
+                        'label' => 'field_definition.eztweet.authorList'
+                    ])
+                    ->addModelTransformer(new StringToArrayTransformer())
+                    // Deactivate auto-initialize as we're not on the root form.
+                    ->setAutoInitialize(false)->getForm()
+            );
+    }
+}

--- a/eZ/Publish/FieldType/Tweet/LegacyConverter.php
+++ b/eZ/Publish/FieldType/Tweet/LegacyConverter.php
@@ -30,12 +30,21 @@ class LegacyConverter implements Converter
 
     public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
     {
-        // @todo implement me
+        $storageDef->dataText1 = json_encode(
+            $fieldDef->fieldTypeConstraints->validators['TweetValueValidator']['authorList']
+        );
     }
 
     public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef)
     {
-        // @todo implement me
+        $authorList = json_decode($storageDef->dataText1);
+        if (!empty($authorList)) {
+            $fieldDef->fieldTypeConstraints->validators = [
+                'TweetValueValidator' => [
+                    'authorList' => $authorList
+                ],
+            ];
+        }
     }
 
     /**

--- a/eZ/Publish/FieldType/Tweet/Type.php
+++ b/eZ/Publish/FieldType/Tweet/Type.php
@@ -22,6 +22,15 @@ class Type extends FieldType
     /** @var TwitterClientInterface */
     protected $twitterClient;
 
+    protected $validatorConfigurationSchema = [
+        'TweetValueValidator' => [
+            'authorList' => [
+                'type' => 'array',
+                'default' => []
+            ]
+        ]
+    ];
+
     public function __construct(TwitterClientInterface $twitterClient)
     {
         $this->twitterClient = $twitterClient;
@@ -162,6 +171,39 @@ class Type extends FieldType
         return new Value($fieldValue->data);
     }
 
+    public function validateValidatorConfiguration($validatorConfiguration)
+    {
+        $validationErrors = [];
+
+        foreach ($validatorConfiguration as $validatorIdentifier => $constraints) {
+            // Report unknown validators
+            if ($validatorIdentifier !== 'TweetValueValidator') {
+                $validationErrors[] = new ValidationError("Validator '$validatorIdentifier' is unknown");
+                continue;
+            }
+
+            // Validate arguments from TweetValueValidator
+            foreach ($constraints as $name => $value) {
+                switch ($name) {
+                    case 'authorList':
+                        if (!is_array($value)) {
+                            $validationErrors[] = new ValidationError('Invalid authorList argument');
+                        }
+                        foreach ($value as $authorName) {
+                            if (!preg_match('/^[a-z0-9_]{1,15}$/i', $authorName)) {
+                                $validationErrors[] = new ValidationError('Invalid twitter username');
+                            }
+                        }
+                        break;
+                    default:
+                        $validationErrors[] = new ValidationError("Validator parameter '$name' is unknown");
+                }
+            }
+        }
+
+        return $validationErrors;
+    }
+
     /**
      * Validates a field based on the validators in the field definition.
      *
@@ -188,8 +230,27 @@ class Type extends FieldType
                 null,
                 ['%url%' => $fieldValue->url]
             );
+
+            return $errors;
+        }
+
+        $author = $m[1];
+        $validatorConfiguration = $fieldDefinition->getValidatorConfiguration();
+        if (!$this->isAuthorApproved($author, $validatorConfiguration)) {
+            $errors[] = new ValidationError(
+                'Twitter user %user% is not in the approved author list',
+                null,
+                ['%user%' => $m[1]]
+            );
         }
 
         return $errors;
+    }
+
+    private function isAuthorApproved($author, $validatorConfiguration)
+    {
+        return !isset($validatorConfiguration['TweetValueValidator'])
+            || empty($validatorConfiguration['TweetValueValidator']['authorList'])
+            || in_array($author, $validatorConfiguration['TweetValueValidator']['authorList']);
     }
 }


### PR DESCRIPTION
Rebased changes from #8. 
JIRA: [EZP-27294](https://jira.ez.no/browse/EZP-27294)

> This PR aims at adding the possibility to declare a list of allowed tweet authors.
This feature currently is signalled throughout the code and in the tutorial documentation but is not implemented fully. My PR adds the missing pieces.

**Commits `Add a validation` and `Tests for the validation` should be reordered after merging to take a place after `Add field view and field definition view templates` and before `Helper for tagging tutorial steps`.**

Related documentation changes: #29.