### PR TITLE
New sample tweet with Pulley-man

### DIFF
--- a/Command/CreateTweetContentCommand.php
+++ b/Command/CreateTweetContentCommand.php
@@ -36,7 +36,12 @@ class CreateTweetContentCommand extends ContainerAwareCommand
             $repository->getContentTypeService()->loadContentTypeByIdentifier('tweet'),
             'eng-GB'
         );
-        $createStruct->setField('tweet', 'https://twitter.com/bdunogier/status/435763219555037184', 'eng-GB');
+        /* Thanks to:
+         * https://twitter.com/Flutchman_Fride
+         * https://twitter.com/comtocode
+         * https://twitter.com/eZSystemsFR
+         */
+        $createStruct->setField('tweet', 'https://twitter.com/Flutchman_Fride/status/847423373940473856', 'eng-GB');
 
         try {
             $contentDraft = $contentService->createContent(

--- a/Resources/misc/create-content.xml
+++ b/Resources/misc/create-content.xml
@@ -16,7 +16,12 @@
         <field>
             <fieldDefinitionIdentifier>tweet</fieldDefinitionIdentifier>
             <languageCode>eng-GB</languageCode>
-            <fieldValue>https://twitter.com/bdunogier/status/355656801909350400</fieldValue>
+            <!-- Thanks to:
+            https://twitter.com/Flutchman_Fride
+            https://twitter.com/comtocode
+            https://twitter.com/eZSystemsFR
+            -->
+            <fieldValue>https://twitter.com/Flutchman_Fride/status/847423373940473856</fieldValue>
         </field>
     </fields>
 </ContentCreate>


### PR DESCRIPTION
Rebased changes from #15. Thank you @glye!

>As discussed in demo, this uses the awesome https://twitter.com/Flutchman_Fride/status/847423373940473856 as a sample tweet, with the attribution requested by the tweeter.
I saw no screenshot in this repo, but if one is needed for the doc page or elsewhere, get it here: https://postimg.org/image/km23qzbf7/c73823f5/

Related documentation changes: #34.