### PR TITLE
Fix tests for PHPUnit 6

### DIFF
--- a/Tests/eZ/Publish/FieldType/TweetSPIIntegrationTest.php
+++ b/Tests/eZ/Publish/FieldType/TweetSPIIntegrationTest.php
@@ -141,7 +141,7 @@ class TweetSPIIntegrationTest extends BaseIntegrationTest
     private function getTwitterClientMock()
     {
         if ($this->twitterClientMock === null) {
-            $this->twitterClientMock = $this->getMock(TwitterClientInterface::class);
+            $this->twitterClientMock = $this->getMockBuilder(TwitterClientInterface::class)->getMock();
         }
 
         return $this->twitterClientMock;

--- a/Tests/eZ/Publish/FieldType/TweetTest.php
+++ b/Tests/eZ/Publish/FieldType/TweetTest.php
@@ -187,7 +187,7 @@ class TweetTest extends FieldTypeTest
     private function getTwitterClientMock()
     {
         if ($this->twitterClientMock === null) {
-            $this->twitterClientMock = $this->getMock(TwitterClientInterface::class);
+            $this->twitterClientMock = $this->getMockBuilder(TwitterClientInterface::class)->getMock();
         }
 
         return $this->twitterClientMock;


### PR DESCRIPTION
This PR aims at adapting the tests for the use with PHPUnit 6.

`$this->getMock()` no longer exists in PHPUnit 6, so I changed it to `$this->getMockBuilder()->getMock()`, which works in both PHPUnit 4 and 6.