### PR TITLE
Add prompt for confirmation before pushing the tags in tagging helper script

### DIFF
--- a/Resources/misc/tag-steps.sh
+++ b/Resources/misc/tag-steps.sh
@@ -30,6 +30,12 @@ do
     fi
 done
 
-git push --tags --force
+echo "Tags created."
 
-echo "Tags created and pushed."
+read -p "Do you want to push tags to a remote repository? " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+    git push --tags --force
+    echo "Tags pushed."
+fi


### PR DESCRIPTION
To be sure that the user of tagging helper doesn't push something by accident, this PR adds prompt for confirmation before pushing the tags. 