### PR TITLE
Handle template declaration issue (eZ > 2.2.x)

### DIFF
--- a/Resources/config/ez_field_templates.yml
+++ b/Resources/config/ez_field_templates.yml
@@ -6,3 +6,6 @@ system:
             - {template: EzSystemsTweetFieldTypeBundle:platformui/content_type/view:eztweet.html.twig, priority: 0}
         fielddefinition_edit_templates:
             - {template: EzSystemsTweetFieldTypeBundle:platformui/content_type/edit:eztweet.html.twig, priority: 0}
+    admin_group:
+        field_templates:
+            - {template: EzSystemsTweetFieldTypeBundle:fields:eztweet.html.twig, priority: 0}


### PR DESCRIPTION
Good morning,

This is a proposition to update `field_templates` configuration in order to handle a weird issue that appears after eZ Platform 2.2.x (definitely here in 2.3.x) where the back-office couldn't find the eztweet field template, even with the `default` group declaration.

Basically, it add the "missing" `admin_group` configuration part. Regarding the current eZ Platform default configuration, i found it more reliable to work this way instead of creating a new siteaccess group which would contains every siteaccesses and then use it.

Thank you in advance for your feedbacks.
